### PR TITLE
feat: add haul observations when resetting a currently active buoy

### DIFF
--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -20,7 +20,6 @@ class EdgeTechAuthConfiguration(AuthActionConfiguration, ExecutableActionMixin):
     )
 
 
-
 class EdgeTechConfiguration(PullActionConfiguration):
     api_base_url: pydantic.AnyHttpUrl = pydantic.Field(
         ...,
@@ -32,8 +31,8 @@ class EdgeTechConfiguration(PullActionConfiguration):
 
     @property
     def v1_url(self):
-        return self.api_base_url + "/v1"
+        return f"{self.api_base_url}/v1"
 
     @property
     def database_dump_url(self):
-        return self.v1_url + "/database-dump/tasks"
+        return f"{self.v1_url}/database-dump/tasks"

--- a/app/actions/edgetech/processor.py
+++ b/app/actions/edgetech/processor.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 import pydantic
 
-from app.actions.buoy import BuoyClient
+from app.actions.buoy import BuoyClient, ObservationSubject
 from app.actions.edgetech.types import Buoy
 
 logger = logging.getLogger(__name__)
@@ -206,7 +206,9 @@ class EdgeTechProcessor:
         for serial_number in update_buoys:
             buoy_records = buoy_states_by_serial_number[serial_number]
             primary_subject_name = f"{self._prefix}{serial_number}_A"
-            er_subject = er_subject_mapping.get(primary_subject_name)
+            er_subject: ObservationSubject = er_subject_mapping.get(
+                primary_subject_name
+            )
             secondary_subject_name = f"{self._prefix}{serial_number}_B"
 
             if er_subject is None:
@@ -223,12 +225,12 @@ class EdgeTechProcessor:
                 try:
                     new_obs, last_known_position, last_known_end_position = (
                         buoy_record.create_observations(
-                            self._prefix,
-                            er_subject.last_position_date,
-                            last_known_position,
-                            last_known_end_position,
-                            was_part_of_trawl,
-                            er_subject.is_active,
+                            prefix=self._prefix,
+                            subject_status=er_subject.last_position_date,
+                            last_observation_timestamp=last_known_position,
+                            last_know_position_previous_states=last_known_end_position,
+                            last_know_end_position_previous_states=was_part_of_trawl,
+                            was_part_of_trawl=was_part_of_trawl,
                         )
                     )
                     buoys_observations.extend(new_obs)

--- a/app/actions/edgetech/processor.py
+++ b/app/actions/edgetech/processor.py
@@ -163,7 +163,7 @@ class EdgeTechProcessor:
 
     def _process_inserts(
         self, insert_buoys: set, buoy_states_by_serial_number: Dict[str, List[Buoy]]
-    ) -> List[dict]:
+    ) -> List[Dict[str, Any]]:
         """
         Creates observation events for buoys that need insertion.
         """
@@ -198,7 +198,7 @@ class EdgeTechProcessor:
         buoy_states_by_serial_number: Dict[str, List[Buoy]],
         er_subject_mapping: Dict[str, Any],
         noop_buoys: set,
-    ) -> List[dict]:
+    ) -> List[Dict[str, Any]]:
         """
         Creates observation events for buoys that need updating, skipping those with no changes (no-op).
         """
@@ -215,7 +215,7 @@ class EdgeTechProcessor:
                 )
                 continue
 
-            was_part_of_trawl = er_subject_mapping.get(secondary_subject_name)
+            was_part_of_trawl = secondary_subject_name in er_subject_mapping
 
             last_known_position, last_known_end_position = None, None
             buoys_observations = []
@@ -228,6 +228,7 @@ class EdgeTechProcessor:
                             last_known_position,
                             last_known_end_position,
                             was_part_of_trawl,
+                            er_subject.is_active,
                         )
                     )
                     buoys_observations.extend(new_obs)
@@ -244,7 +245,7 @@ class EdgeTechProcessor:
 
         return observations
 
-    async def process(self) -> List[dict]:
+    async def process(self) -> Tuple[List[Dict[str, Any]], Set[str], Set[str]]:
         """
         Process buoy data to generate observation events for the ER system.
 
@@ -260,6 +261,8 @@ class EdgeTechProcessor:
 
         Returns:
             List[dict]: A list of dictionaries representing the observation events generated during processing.
+            Set[str]: A set of serial numbers for buoys that were inserted.
+            Set[str]: A set of serial numbers for buoys that were updated.
         Raises:
             pydantic.ValidationError: If validation fails while creating buoy observation events.
         """

--- a/app/actions/edgetech/types.py
+++ b/app/actions/edgetech/types.py
@@ -137,8 +137,8 @@ class Buoy(pydantic.BaseModel):
         start_lon: float,
         end_lat: Optional[float],
         end_lon: Optional[float],
+        subject_status: bool,
         was_part_of_trawl: bool = False,
-        subject_status: bool = False,
     ) -> List[Dict[str, Any]]:
         """
         Return one or two observations for deployment or retrieval events,
@@ -221,7 +221,10 @@ class Buoy(pydantic.BaseModel):
         return observations
 
     def generate_observations_from_change_records(
-        self, prefix: str, last_observation_timestamp: Optional[datetime] = None
+        self,
+        prefix: str,
+        subject_status: bool,
+        last_observation_timestamp: Optional[datetime] = None,
     ) -> Tuple[List[Dict[str, Any]], Optional[GeoLocation], Optional[GeoLocation]]:
         """
         Generate observations from deployment or retrieval changes in the changeRecords.
@@ -303,6 +306,7 @@ class Buoy(pydantic.BaseModel):
                 start_lon=lon,
                 end_lat=end_lat,
                 end_lon=end_lon,
+                subject_status=subject_status,
             )
             observations.extend(event_observations)
 
@@ -311,11 +315,11 @@ class Buoy(pydantic.BaseModel):
     def create_observations(
         self,
         prefix: str,
+        subject_status: bool,
         last_observation_timestamp: Optional[datetime] = None,
         last_know_position_previous_states: Optional[GeoLocation] = None,
         last_know_end_position_previous_states: Optional[GeoLocation] = None,
         was_part_of_trawl: bool = False,
-        subject_status: bool = False,
     ) -> Tuple[List[Dict[str, Any]], Optional[GeoLocation], Optional[GeoLocation]]:
         """
         Return observations from the current state or from changeRecords if available.
@@ -327,7 +331,9 @@ class Buoy(pydantic.BaseModel):
         if self.changeRecords:
             observations, last_known_position, last_known_end_position = (
                 self.generate_observations_from_change_records(
-                    prefix, last_observation_timestamp
+                    prefix=prefix,
+                    last_observation_timestamp=last_observation_timestamp,
+                    subject_status=subject_status,
                 )
             )
 

--- a/app/actions/tests/conftest.py
+++ b/app/actions/tests/conftest.py
@@ -57,6 +57,7 @@ def a_good_auth_configuration():
         token_url="https://edgetech.api/token",
     )
 
+
 @pytest.fixture
 def a_good_pull_configuration():
     return EdgeTechConfiguration(
@@ -667,6 +668,31 @@ def get_mock_edgetech_data():
                     "changes": [],
                 }
             ],
+        },
+        {
+            "serialNumber": "88CE99DA78",
+            "currentState": {
+                "etag": "1742573159395",
+                "isDeleted": False,
+                "positionSetByCapri": False,
+                "serialNumber": "88CE99DA78",
+                "releaseCommand": "C8AB8C7578",
+                "statusCommand": "88CE99DA78",
+                "idCommand": "CCCCCCCCCC",
+                "isNfcTag": True,
+                "latDeg": 49.30788893117735,
+                "lonDeg": -123.23345710912099,
+                "modelNumber": "5112",
+                "dateOfManufacture": "2024-03-23T07:00:00.000Z",
+                "isDeployed": True,
+                "dateDeployed": "2025-03-21T16:05:59.063Z",
+                "dateStatus": "2025-03-17T17:16:47.958Z",
+                "statusRangeM": 91.378,
+                "statusIsTilted": False,
+                "statusBatterySoC": 68,
+                "lastUpdated": "2025-03-21T16:05:59.395Z",
+            },
+            "changeRecords": [],
         },
     ]
 
@@ -1316,6 +1342,140 @@ def get_er_subjects_updated_data():
             "device_status_properties": None,
             "url": "https://buoy.dev.pamdas.org/api/v1.0/subject/ba4c1908-cf3b-4f7c-af9f-25da7c3d1187",
         },
+        {
+            "content_type": "observations.subject",
+            "id": "15aa5d3a-c37f-40fc-88eb-f35a393ebd9c",
+            "name": "edgetech_88CE99DA78_A",
+            "subject_type": "unassigned",
+            "subject_subtype": "ropeless_buoy_device",
+            "common_name": None,
+            "additional": {
+                "devices": [
+                    {
+                        "label": "a",
+                        "location": {
+                            "latitude": 49.30788893117735,
+                            "longitude": -123.23345710912099,
+                        },
+                        "device_id": "edgetech_88CE99DA78_A",
+                        "last_updated": "2025-03-21T16:05:59+00:00",
+                    }
+                ],
+                "display_id": "e708eaee1be5",
+                "event_type": "gear_deployed",
+                "subject_name": "edgetech_88CE99DA78_A",
+                "subject_is_active": True,
+                "edgetech_serial_number": "88CE99DA78",
+            },
+            "created_at": "2025-03-10T10:00:15.416754-07:00",
+            "updated_at": "2025-04-18T16:31:11.970117-07:00",
+            "is_active": True,
+            "user": None,
+            "tracks_available": True,
+            "image_url": "/static/pin-black.svg",
+            "last_position_status": {
+                "last_voice_call_start_at": None,
+                "radio_state_at": None,
+                "radio_state": "na",
+            },
+            "last_position_date": "2025-03-20T16:05:59+00:00",
+            "last_position": {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [-123.233457109121, 49.30788893117735],
+                },
+                "properties": {
+                    "title": "edgetech_88CE99DA78_A",
+                    "subject_type": "unassigned",
+                    "subject_subtype": "ropeless_buoy_device",
+                    "id": "15aa5d3a-c37f-40fc-88eb-f35a393ebd9c",
+                    "stroke": "#FFFF00",
+                    "stroke-opacity": 1.0,
+                    "stroke-width": 2,
+                    "image": "https://buoy.pamdas.org/static/pin-black.svg",
+                    "last_voice_call_start_at": None,
+                    "location_requested_at": None,
+                    "radio_state_at": "1970-01-01T00:00:00+00:00",
+                    "radio_state": "na",
+                    "coordinateProperties": {"time": "2025-03-21T16:05:59+00:00"},
+                    "DateTime": "2025-03-21T16:05:59+00:00",
+                },
+            },
+            "device_status_properties": None,
+            "url": "https://buoy.pamdas.org/api/v1.0/subject/15aa5d3a-c37f-40fc-88eb-f35a393ebd9c",
+        },
+        {
+            "content_type": "observations.subject",
+            "id": "b7c073c0-210c-4c2a-afba-77774d1d3dd3",
+            "name": "edgetech_88CE99DA78_B",
+            "subject_type": "unassigned",
+            "subject_subtype": "ropeless_buoy_device",
+            "common_name": None,
+            "additional": {
+                "devices": [
+                    {
+                        "label": "a",
+                        "location": {
+                            "latitude": 48.41639352795489,
+                            "longitude": -123.38347494713835,
+                        },
+                        "device_id": "edgetech_88CE99DA78_A",
+                        "last_updated": "2025-03-10T18:45:04.774000+00:00",
+                    },
+                    {
+                        "label": "b",
+                        "location": {
+                            "latitude": 48.4048796411028,
+                            "longitude": -123.40832268543033,
+                        },
+                        "device_id": "edgetech_88CE99DA78_B",
+                        "last_updated": "2025-03-10T18:45:04.774000+00:00",
+                    },
+                ],
+                "display_id": "88CE99DA78",
+                "event_type": "gear_deployed",
+                "subject_name": "edgetech_88CE99DA78_B",
+                "edgetech_serial_number": "88CE99DA78",
+            },
+            "created_at": "2025-03-10T11:50:13.145941-07:00",
+            "updated_at": "2025-03-10T11:50:13.145962-07:00",
+            "is_active": True,
+            "user": None,
+            "tracks_available": True,
+            "image_url": "/static/pin-black.svg",
+            "last_position_status": {
+                "last_voice_call_start_at": None,
+                "radio_state_at": None,
+                "radio_state": "na",
+            },
+            "last_position_date": "2025-03-20T15:40:27+00:00",
+            "last_position": {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [-123.2350105886564, 49.30751795885089],
+                },
+                "properties": {
+                    "title": "edgetech_88CE99DA78_B",
+                    "subject_type": "unassigned",
+                    "subject_subtype": "ropeless_buoy_device",
+                    "id": "b7c073c0-210c-4c2a-afba-77774d1d3dd3",
+                    "stroke": "#FFFF00",
+                    "stroke-opacity": 1.0,
+                    "stroke-width": 2,
+                    "image": "https://buoy.pamdas.org/static/pin-black.svg",
+                    "last_voice_call_start_at": None,
+                    "location_requested_at": None,
+                    "radio_state_at": "1970-01-01T00:00:00+00:00",
+                    "radio_state": "na",
+                    "coordinateProperties": {"time": "2025-03-21T15:40:27+00:00"},
+                    "DateTime": "2025-03-21T15:40:27+00:00",
+                },
+            },
+            "device_status_properties": None,
+            "url": "https://buoy.pamdas.org/api/v1.0/subject/b7c073c0-210c-4c2a-afba-77774d1d3dd3",
+        },
     ]
 
 
@@ -1593,6 +1753,33 @@ def get_expected_observations_test_edgetech_processor_inserting_buoys():
             },
         },
         {
+            "name": "edgetech_88CE99DA78_A",
+            "source": "edgetech_88CE99DA78_A",
+            "type": "ropeless_buoy",
+            "subject_type": "ropeless_buoy_device",
+            "is_active": True,
+            "recorded_at": "2025-03-21T16:05:59+00:00",
+            "location": {"lat": 49.30788893117735, "lon": -123.23345710912099},
+            "additional": {
+                "subject_name": "edgetech_88CE99DA78_A",
+                "edgetech_serial_number": "88CE99DA78",
+                "display_id": "e708eaee1be5",
+                "subject_is_active": True,
+                "event_type": "gear_deployed",
+                "devices": [
+                    {
+                        "label": "a",
+                        "location": {
+                            "latitude": 49.30788893117735,
+                            "longitude": -123.23345710912099,
+                        },
+                        "device_id": "edgetech_88CE99DA78_A",
+                        "last_updated": "2025-03-21T16:05:59+00:00",
+                    }
+                ],
+            },
+        },
+        {
             "name": "edgetech_88CE99D9CB_A",
             "source": "edgetech_88CE99D9CB_A",
             "type": "ropeless_buoy",
@@ -1738,6 +1925,33 @@ def get_expected_observations_test_create_observations_with_last_updated_timesta
                         "location": {"latitude": 42.2290093, "longitude": -70.6304546},
                         "device_id": "edgetech_88CE99D9CB_A",
                         "last_updated": "2025-04-10T16:24:20+00:00",
+                    }
+                ],
+            },
+        },
+        {
+            "name": "edgetech_88CE99DA78_A",
+            "source": "edgetech_88CE99DA78_A",
+            "type": "ropeless_buoy",
+            "subject_type": "ropeless_buoy_device",
+            "is_active": True,
+            "recorded_at": "2025-03-21T16:05:59+00:00",
+            "location": {"lat": 49.30788893117735, "lon": -123.23345710912099},
+            "additional": {
+                "subject_name": "edgetech_88CE99DA78_A",
+                "edgetech_serial_number": "88CE99DA78",
+                "display_id": "e708eaee1be5",
+                "subject_is_active": True,
+                "event_type": "gear_deployed",
+                "devices": [
+                    {
+                        "label": "a",
+                        "location": {
+                            "latitude": 49.30788893117735,
+                            "longitude": -123.23345710912099,
+                        },
+                        "device_id": "edgetech_88CE99DA78_A",
+                        "last_updated": "2025-03-21T16:05:59+00:00",
                     }
                 ],
             },
@@ -2022,6 +2236,33 @@ def get_expected_observations_test_create_observations():
             },
         },
         {
+            "name": "edgetech_88CE99DA78_A",
+            "source": "edgetech_88CE99DA78_A",
+            "type": "ropeless_buoy",
+            "subject_type": "ropeless_buoy_device",
+            "is_active": True,
+            "recorded_at": "2025-03-21T16:05:59+00:00",
+            "location": {"lat": 49.30788893117735, "lon": -123.23345710912099},
+            "additional": {
+                "subject_name": "edgetech_88CE99DA78_A",
+                "edgetech_serial_number": "88CE99DA78",
+                "display_id": "e708eaee1be5",
+                "subject_is_active": True,
+                "event_type": "gear_deployed",
+                "devices": [
+                    {
+                        "label": "a",
+                        "location": {
+                            "latitude": 49.30788893117735,
+                            "longitude": -123.23345710912099,
+                        },
+                        "device_id": "edgetech_88CE99DA78_A",
+                        "last_updated": "2025-03-21T16:05:59+00:00",
+                    }
+                ],
+            },
+        },
+        {
             "name": "edgetech_88CE99D9CB_A",
             "source": "edgetech_88CE99D9CB_A",
             "type": "ropeless_buoy",
@@ -2144,6 +2385,147 @@ def get_expected_observations_test_create_observations_recored_at_same_as_curren
                         "device_id": "edgetech_88CE99D9CB_A",
                         "last_updated": "2025-04-10T16:24:20+00:00",
                     }
+                ],
+            },
+        },
+        {
+            "name": "edgetech_88CE99DA78_A",
+            "source": "edgetech_88CE99DA78_A",
+            "type": "ropeless_buoy",
+            "subject_type": "ropeless_buoy_device",
+            "is_active": True,
+            "recorded_at": "2025-03-21T16:05:59+00:00",
+            "location": {"lat": 49.30788893117735, "lon": -123.23345710912099},
+            "additional": {
+                "subject_name": "edgetech_88CE99DA78_A",
+                "edgetech_serial_number": "88CE99DA78",
+                "display_id": "e708eaee1be5",
+                "subject_is_active": True,
+                "event_type": "gear_deployed",
+                "devices": [
+                    {
+                        "label": "a",
+                        "location": {
+                            "latitude": 49.30788893117735,
+                            "longitude": -123.23345710912099,
+                        },
+                        "device_id": "edgetech_88CE99DA78_A",
+                        "last_updated": "2025-03-21T16:05:59+00:00",
+                    }
+                ],
+            },
+        },
+    ]
+
+
+@pytest.fixture
+def get_observations_update_buoys():
+    return [
+        {
+            "name": "edgetech_88CE99DA78_A",
+            "source": "edgetech_88CE99DA78_A",
+            "type": "ropeless_buoy",
+            "subject_type": "ropeless_buoy_device",
+            "is_active": True,
+            "recorded_at": "2025-03-21T16:05:59+00:00",
+            "location": {"lat": 49.30788893117735, "lon": -123.23345710912099},
+            "additional": {
+                "subject_name": "edgetech_88CE99DA78_A",
+                "edgetech_serial_number": "88CE99DA78",
+                "display_id": "e708eaee1be5",
+                "subject_is_active": True,
+                "event_type": "gear_deployed",
+                "devices": [
+                    {
+                        "label": "a",
+                        "location": {
+                            "latitude": 49.30788893117735,
+                            "longitude": -123.23345710912099,
+                        },
+                        "device_id": "edgetech_88CE99DA78_A",
+                        "last_updated": "2025-03-21T16:05:59+00:00",
+                    },
+                    {
+                        "label": "b",
+                        "location": {
+                            "latitude": 49.30788893117735,
+                            "longitude": -123.23345710912099,
+                        },
+                        "device_id": "edgetech_88CE99DA78_B",
+                        "last_updated": "2025-03-21T16:05:59+00:00",
+                    },
+                ],
+            },
+        },
+        {
+            "name": "edgetech_88CE99DA78_A",
+            "source": "edgetech_88CE99DA78_A",
+            "type": "ropeless_buoy",
+            "subject_type": "ropeless_buoy_device",
+            "is_active": False,
+            "recorded_at": "2025-03-21T16:04:59+00:00",
+            "location": {"lat": 49.30788893117735, "lon": -123.23345710912099},
+            "additional": {
+                "subject_name": "edgetech_88CE99DA78_A",
+                "edgetech_serial_number": "88CE99DA78",
+                "display_id": "e2d54db783f6",
+                "subject_is_active": False,
+                "event_type": "gear_retrieved",
+                "devices": [
+                    {
+                        "label": "a",
+                        "location": {
+                            "latitude": 49.30788893117735,
+                            "longitude": -123.23345710912099,
+                        },
+                        "device_id": "edgetech_88CE99DA78_A",
+                        "last_updated": "2025-03-21T16:05:59+00:00",
+                    },
+                    {
+                        "label": "b",
+                        "location": {
+                            "latitude": 49.30788893117735,
+                            "longitude": -123.23345710912099,
+                        },
+                        "device_id": "edgetech_88CE99DA78_B",
+                        "last_updated": "2025-03-21T16:05:59+00:00",
+                    },
+                ],
+            },
+        },
+        {
+            "name": "edgetech_88CE99DA78_B",
+            "source": "edgetech_88CE99DA78_B",
+            "type": "ropeless_buoy",
+            "subject_type": "ropeless_buoy_device",
+            "is_active": False,
+            "recorded_at": "2025-03-21T16:04:59+00:00",
+            "location": {"lat": 49.30788893117735, "lon": -123.23345710912099},
+            "additional": {
+                "subject_name": "edgetech_88CE99DA78_B",
+                "edgetech_serial_number": "88CE99DA78",
+                "display_id": "e2d54db783f6",
+                "subject_is_active": False,
+                "event_type": "gear_retrieved",
+                "devices": [
+                    {
+                        "label": "a",
+                        "location": {
+                            "latitude": 49.30788893117735,
+                            "longitude": -123.23345710912099,
+                        },
+                        "device_id": "edgetech_88CE99DA78_A",
+                        "last_updated": "2025-03-21T16:05:59+00:00",
+                    },
+                    {
+                        "label": "b",
+                        "location": {
+                            "latitude": 49.30788893117735,
+                            "longitude": -123.23345710912099,
+                        },
+                        "device_id": "edgetech_88CE99DA78_B",
+                        "last_updated": "2025-03-21T16:05:59+00:00",
+                    },
                 ],
             },
         },

--- a/app/actions/tests/test_edgetech_processor.py
+++ b/app/actions/tests/test_edgetech_processor.py
@@ -7,7 +7,10 @@ from app.actions.edgetech.types import Buoy
 
 @pytest.mark.asyncio
 async def test_edgetech_processor_updated_buoys(
-    mocker, get_mock_edgetech_data, get_er_subjects_updated_data
+    mocker,
+    get_mock_edgetech_data,
+    get_er_subjects_updated_data,
+    get_observations_update_buoys,
 ):
     """
     Test if the EdgeTechProcessor returns the correct updated buoys
@@ -28,9 +31,9 @@ async def test_edgetech_processor_updated_buoys(
     # Act
     processor = EdgeTechProcessor(buoys, "er_token", "er_token")
     observations, inserts_buoys, update_buoys = await processor.process()
-    assert observations == []
+    assert observations == get_observations_update_buoys
     assert inserts_buoys == set()
-    assert update_buoys == set()
+    assert update_buoys == {"88CE99DA78"}
 
 
 @pytest.mark.asyncio
@@ -63,7 +66,7 @@ async def test_edgetech_processor_inserting_buoys(
     )
 
     # Leave out the 88CE9978AE since it doesn't have a record with location info
-    expected_inserts_buoys = {"88CE999763", "88CE99D9CB", "88CE99C99A"}
+    expected_inserts_buoys = {"88CE999763", "88CE99D9CB", "88CE99C99A", "88CE99DA78"}
 
     # Assert
     observations.sort(key=lambda x: x["recorded_at"])


### PR DESCRIPTION
# Description

This PR adds logic to include a new observation that "hauls" the subjects of a trawl in case a new "deployment" is found when the Gearset is still "active"/"deployed".

# Related Issue
https://allenai.atlassian.net/browse/RF-959