### PR TITLE
fix: comment out use of isDeleted when evaluating deploy status

### DIFF
--- a/app/actions/edgetech/types.py
+++ b/app/actions/edgetech/types.py
@@ -75,8 +75,11 @@ class Buoy(pydantic.BaseModel):
     @property
     def deployed(self) -> bool:
         isDeployed = self.currentState.isDeployed or False
-        isDeleted = self.currentState.isDeleted or False
-        return isDeployed and not isDeleted
+        # RF-976: Buoys that were expected to be shown weren't
+        # because they were marked as deleted in the database.
+        # This is a workaround to show them in the map.
+        # isDeleted = self.currentState.isDeleted or False
+        return isDeployed  # and not isDeleted
 
     def _create_device_record(
         self,


### PR DESCRIPTION
# Description

Some gears were expected to appear but didn’t, because they had isDeleted set to true, causing them to be treated as “not deployed”. This PR comments out the isDeleted check, considering only the isDeployed flag.as

# Related Issue
https://allenai.atlassian.net/browse/RF-976