### PR TITLE
feat: add support to userId field

### DIFF
--- a/app/actions/edgetech/types.py
+++ b/app/actions/edgetech/types.py
@@ -72,6 +72,7 @@ class Buoy(pydantic.BaseModel):
 
     currentState: CurrentState
     serialNumber: str
+    userId: str
     changeRecords: List[ChangeRecord]
 
     @property
@@ -172,11 +173,11 @@ class Buoy(pydantic.BaseModel):
 
         devices = []
         if end_unit_serial:
-            subject_name_a = f"{prefix}{self.serialNumber}"
-            subject_name_b = f"{prefix}{end_unit_serial}"
+            subject_name_a = f"{prefix}{self.serialNumber}_{self.userId}"
+            subject_name_b = f"{prefix}{end_unit_serial}_{self.userId}"
         else:
-            subject_name_a = f"{prefix}{self.serialNumber}_A"
-            subject_name_b = f"{prefix}{self.serialNumber}_B"
+            subject_name_a = f"{prefix}{self.serialNumber}_{self.userId}_A"
+            subject_name_b = f"{prefix}{self.serialNumber}_{self.userId}_B"
 
         device_a = self._create_device_record(
             "a", start_lat, start_lon, subject_name_a, recorded_at

--- a/app/actions/tests/conftest.py
+++ b/app/actions/tests/conftest.py
@@ -16,6 +16,7 @@ def a_new_edgetech_trawl_record():
     """Fixture to create a sample EdgeTech record."""
     return {
         "serialNumber": "8899CEDAAA",
+        "userId": "7889ad74-aab3-4044-bcf4-13d6f9586a82",
         "currentState": {
             "etag": "1748195599731",
             "isDeleted": False,

--- a/app/actions/tests/test_edgetech_processor.py
+++ b/app/actions/tests/test_edgetech_processor.py
@@ -28,32 +28,32 @@ async def test_process_new_edgetech_trawl(mocker, a_new_edgetech_trawl_record):
 
     # Assert
     logger.info(f"Processed observations: {observations}")
-    expected_observvations = [
+    expected_observations = [
         {
-            "name": "edgetech_8899CEDAAA_A",
-            "source": "edgetech_8899CEDAAA_A",
+            "name": "edgetech_8899CEDAAA_7889ad74-aab3-4044-bcf4-13d6f9586a82_A",
+            "source": "edgetech_8899CEDAAA_7889ad74-aab3-4044-bcf4-13d6f9586a82_A",
             "type": "ropeless_buoy",
             "subject_type": "ropeless_buoy_device",
             "is_active": True,
             "recorded_at": "2025-05-25T17:53:19+00:00",
             "location": {"lat": 44.358265, "lon": -68.16757},
             "additional": {
-                "subject_name": "edgetech_8899CEDAAA_A",
+                "subject_name": "edgetech_8899CEDAAA_7889ad74-aab3-4044-bcf4-13d6f9586a82_A",
                 "edgetech_serial_number": "8899CEDAAA",
-                "display_id": "12daa93d83a5",
+                "display_id": "f4ca7c991959",
                 "subject_is_active": True,
                 "event_type": "gear_deployed",
                 "devices": [
                     {
                         "label": "a",
                         "location": {"latitude": 44.358265, "longitude": -68.16757},
-                        "device_id": "edgetech_8899CEDAAA_A",
+                        "device_id": "edgetech_8899CEDAAA_7889ad74-aab3-4044-bcf4-13d6f9586a82_A",
                         "last_updated": "2025-05-25T17:53:19+00:00",
                     },
                     {
                         "label": "b",
                         "location": {"latitude": 44.3591792, "longitude": -68.167191},
-                        "device_id": "edgetech_8899CEDAAA_B",
+                        "device_id": "edgetech_8899CEDAAA_7889ad74-aab3-4044-bcf4-13d6f9586a82_B",
                         "last_updated": "2025-05-25T17:53:19+00:00",
                     },
                 ],
@@ -70,7 +70,14 @@ async def test_process_new_edgetech_trawl(mocker, a_new_edgetech_trawl_record):
                         "dateOfManufacture": None,
                         "dateOfBatteryChange": None,
                         "dateDeployed": datetime(
-                            2025, 5, 25, 17, 53, 19, 517000, tzinfo=timezone.utc
+                            2025,
+                            5,
+                            25,
+                            17,
+                            53,
+                            19,
+                            517000,
+                            tzinfo=timezone.utc,
                         ),
                         "isDeployed": True,
                         "dateRecovered": None,
@@ -82,7 +89,14 @@ async def test_process_new_edgetech_trawl(mocker, a_new_edgetech_trawl_record):
                         "statusIsTilted": None,
                         "statusBatterySoC": None,
                         "lastUpdated": datetime(
-                            2025, 5, 25, 17, 53, 19, 731000, tzinfo=timezone.utc
+                            2025,
+                            5,
+                            25,
+                            17,
+                            53,
+                            19,
+                            731000,
+                            tzinfo=timezone.utc,
                         ),
                         "latDeg": 44.358265,
                         "lonDeg": -68.16757,
@@ -93,34 +107,35 @@ async def test_process_new_edgetech_trawl(mocker, a_new_edgetech_trawl_record):
                         "startUnit": None,
                     },
                     "serialNumber": "8899CEDAAA",
+                    "userId": "7889ad74-aab3-4044-bcf4-13d6f9586a82",
                 },
             },
         },
         {
-            "name": "edgetech_8899CEDAAA_B",
-            "source": "edgetech_8899CEDAAA_B",
+            "name": "edgetech_8899CEDAAA_7889ad74-aab3-4044-bcf4-13d6f9586a82_B",
+            "source": "edgetech_8899CEDAAA_7889ad74-aab3-4044-bcf4-13d6f9586a82_B",
             "type": "ropeless_buoy",
             "subject_type": "ropeless_buoy_device",
             "is_active": True,
             "recorded_at": "2025-05-25T17:53:19+00:00",
             "location": {"lat": 44.3591792, "lon": -68.167191},
             "additional": {
-                "subject_name": "edgetech_8899CEDAAA_B",
+                "subject_name": "edgetech_8899CEDAAA_7889ad74-aab3-4044-bcf4-13d6f9586a82_B",
                 "edgetech_serial_number": "8899CEDAAA",
-                "display_id": "12daa93d83a5",
+                "display_id": "f4ca7c991959",
                 "subject_is_active": True,
                 "event_type": "gear_deployed",
                 "devices": [
                     {
                         "label": "a",
                         "location": {"latitude": 44.358265, "longitude": -68.16757},
-                        "device_id": "edgetech_8899CEDAAA_A",
+                        "device_id": "edgetech_8899CEDAAA_7889ad74-aab3-4044-bcf4-13d6f9586a82_A",
                         "last_updated": "2025-05-25T17:53:19+00:00",
                     },
                     {
                         "label": "b",
                         "location": {"latitude": 44.3591792, "longitude": -68.167191},
-                        "device_id": "edgetech_8899CEDAAA_B",
+                        "device_id": "edgetech_8899CEDAAA_7889ad74-aab3-4044-bcf4-13d6f9586a82_B",
                         "last_updated": "2025-05-25T17:53:19+00:00",
                     },
                 ],
@@ -137,7 +152,14 @@ async def test_process_new_edgetech_trawl(mocker, a_new_edgetech_trawl_record):
                         "dateOfManufacture": None,
                         "dateOfBatteryChange": None,
                         "dateDeployed": datetime(
-                            2025, 5, 25, 17, 53, 19, 517000, tzinfo=timezone.utc
+                            2025,
+                            5,
+                            25,
+                            17,
+                            53,
+                            19,
+                            517000,
+                            tzinfo=timezone.utc,
                         ),
                         "isDeployed": True,
                         "dateRecovered": None,
@@ -149,7 +171,14 @@ async def test_process_new_edgetech_trawl(mocker, a_new_edgetech_trawl_record):
                         "statusIsTilted": None,
                         "statusBatterySoC": None,
                         "lastUpdated": datetime(
-                            2025, 5, 25, 17, 53, 19, 731000, tzinfo=timezone.utc
+                            2025,
+                            5,
+                            25,
+                            17,
+                            53,
+                            19,
+                            731000,
+                            tzinfo=timezone.utc,
                         ),
                         "latDeg": 44.358265,
                         "lonDeg": -68.16757,
@@ -160,12 +189,12 @@ async def test_process_new_edgetech_trawl(mocker, a_new_edgetech_trawl_record):
                         "startUnit": None,
                     },
                     "serialNumber": "8899CEDAAA",
+                    "userId": "7889ad74-aab3-4044-bcf4-13d6f9586a82",
                 },
             },
         },
     ]
-    logger.info(observations)
-    assert observations == expected_observvations
+    assert observations == expected_observations
 
 
 @pytest.mark.asyncio
@@ -216,4 +245,5 @@ async def test_process_deployed_in_er_missing_in_edgetech(
             },
         }
     ]
+    logger.info(observations)
     assert observations == expected_observations

--- a/app/actions/tests/test_edgetech_processor.py
+++ b/app/actions/tests/test_edgetech_processor.py
@@ -245,5 +245,5 @@ async def test_process_deployed_in_er_missing_in_edgetech(
             },
         }
     ]
-    logger.info(observations)
+    # Removed redundant logger.info call to avoid cluttering test output.
     assert observations == expected_observations

--- a/app/actions/tests/test_edgetech_types.py
+++ b/app/actions/tests/test_edgetech_types.py
@@ -59,14 +59,24 @@ def base_state():
 def test_has_location_variants(base_state, override, expected):
     state_kwargs = {**base_state, **override}
     state = CurrentState(**state_kwargs)
-    buoy = Buoy(currentState=state, serialNumber="S123", changeRecords=[])
+    buoy = Buoy(
+        userId="7889ad74-aab3-4044-bcf4-13d6f9586a82",
+        currentState=state,
+        serialNumber="S123",
+        changeRecords=[],
+    )
     assert buoy.has_location is expected
 
 def test_create_observations_skips_when_no_start_location(caplog, base_state):
     # Neither latDeg nor lonDeg set → no observations
     state_kwargs = {**base_state, "latDeg": None, "lonDeg": None}
     state = CurrentState(**state_kwargs)
-    buoy = Buoy(currentState=state, serialNumber="S123", changeRecords=[])
+    buoy = Buoy(
+        userId="7889ad74-aab3-4044-bcf4-13d6f9586a82",
+        currentState=state,
+        serialNumber="S123",
+        changeRecords=[],
+    )
 
     caplog.set_level(logging.WARNING)
     obs = buoy.create_observations(prefix="pre_", is_deployed=True)
@@ -84,14 +94,19 @@ def test_create_observations_only_start_point(base_state):
         "dateDeployed": None,  # fallback to lastUpdated
     }
     state = CurrentState(**state_kwargs)
-    buoy = Buoy(currentState=state, serialNumber="S123", changeRecords=[])
+    buoy = Buoy(
+        userId="7889ad74-aab3-4044-bcf4-13d6f9586a82",
+        currentState=state,
+        serialNumber="S123",
+        changeRecords=[],
+    )
 
     obs = buoy.create_observations(prefix="pf_", is_deployed=True)
     assert len(obs) == 1
 
     o = obs[0]
     iso = state.lastUpdated.replace(microsecond=0).isoformat()
-    subj = "pf_S123_A"
+    subj = "pf_S123_7889ad74-aab3-4044-bcf4-13d6f9586a82_A"
     # device record embedded
     device = o["additional"]["devices"][0]
     assert device == {
@@ -120,14 +135,19 @@ def test_create_observations_with_end_points(base_state):
         "endLonDeg": end[1],
     }
     state = CurrentState(**state_kwargs)
-    buoy = Buoy(currentState=state, serialNumber="S123", changeRecords=[])
+    buoy = Buoy(
+        userId="7889ad74-aab3-4044-bcf4-13d6f9586a82",
+        currentState=state,
+        serialNumber="S123",
+        changeRecords=[],
+    )
 
     obs = buoy.create_observations(prefix="XX_", is_deployed=False)
     assert len(obs) == 2
 
     iso = state.lastUpdated.replace(microsecond=0).isoformat()
-    subj_a = "XX_S123_A"
-    subj_b = "XX_S123_B"
+    subj_a = "XX_S123_7889ad74-aab3-4044-bcf4-13d6f9586a82_A"
+    subj_b = "XX_S123_7889ad74-aab3-4044-bcf4-13d6f9586a82_B"
     # check devices list length
     devices = obs[0]["additional"]["devices"]
     assert len(devices) == 2
@@ -157,7 +177,12 @@ def test_create_observations_with_two_unit_line_new_structure(base_state):
         "endUnit": "S456",
     }
     start_state = CurrentState(**start_state_kwargs)
-    start_buoy = Buoy(currentState=start_state, serialNumber="S123", changeRecords=[])
+    start_buoy = Buoy(
+        userId="7889ad74-aab3-4044-bcf4-13d6f9586a82",
+        currentState=start_state,
+        serialNumber="S123",
+        changeRecords=[],
+    )
 
     # Create end unit state
     end_state_kwargs = {
@@ -168,15 +193,20 @@ def test_create_observations_with_two_unit_line_new_structure(base_state):
         "startUnit": "S123",
     }
     end_state = CurrentState(**end_state_kwargs)
-    end_buoy = Buoy(currentState=end_state, serialNumber="S456", changeRecords=[])
+    end_buoy = Buoy(
+        userId="7889ad74-aab3-4044-bcf4-13d6f9586a82",
+        currentState=end_state,
+        serialNumber="S456",
+        changeRecords=[],
+    )
 
     # Create observations using the new structure
     obs = start_buoy.create_observations(prefix="XX_", is_deployed=True, end_unit_buoy=end_buoy)
     assert len(obs) == 2
 
     iso = start_state.lastUpdated.replace(microsecond=0).isoformat()
-    subj_a = "XX_S123"
-    subj_b = "XX_S456"
+    subj_a = "XX_S123_7889ad74-aab3-4044-bcf4-13d6f9586a82"
+    subj_b = "XX_S456_7889ad74-aab3-4044-bcf4-13d6f9586a82"
     
     # Check devices list length
     devices = obs[0]["additional"]["devices"]
@@ -206,7 +236,12 @@ def test_create_observations_with_two_unit_line_missing_end_unit(caplog, base_st
         "endUnit": "S456",  # End unit that doesn't exist
     }
     state = CurrentState(**state_kwargs)
-    buoy = Buoy(currentState=state, serialNumber="S123", changeRecords=[])
+    buoy = Buoy(
+        userId="7889ad74-aab3-4044-bcf4-13d6f9586a82",
+        currentState=state,
+        serialNumber="S123",
+        changeRecords=[],
+    )
 
     caplog.set_level(logging.WARNING)
     obs = buoy.create_observations(prefix="XX_", is_deployed=True, end_unit_buoy=None)
@@ -214,7 +249,7 @@ def test_create_observations_with_two_unit_line_missing_end_unit(caplog, base_st
     # Should still create observation for start unit
     assert len(obs) == 1
     assert obs[0]["location"] == {"lat": start[0], "lon": start[1]}
-    assert obs[0]["name"] == "XX_S123"
+    assert obs[0]["name"] == "XX_S123_7889ad74-aab3-4044-bcf4-13d6f9586a82"
 
 def test_create_observations_with_two_unit_line_old_structure(base_state):
     """Test creating observations for a two-unit line using the old structure."""
@@ -229,14 +264,19 @@ def test_create_observations_with_two_unit_line_old_structure(base_state):
         "isTwoUnitLine": True,
     }
     state = CurrentState(**state_kwargs)
-    buoy = Buoy(currentState=state, serialNumber="S123", changeRecords=[])
+    buoy = Buoy(
+        userId="7889ad74-aab3-4044-bcf4-13d6f9586a82",
+        currentState=state,
+        serialNumber="S123",
+        changeRecords=[],
+    )
 
     obs = buoy.create_observations(prefix="XX_", is_deployed=True)
     assert len(obs) == 2
 
     iso = state.lastUpdated.replace(microsecond=0).isoformat()
-    subj_a = "XX_S123_A"
-    subj_b = "XX_S123_B"
+    subj_a = "XX_S123_7889ad74-aab3-4044-bcf4-13d6f9586a82_A"
+    subj_b = "XX_S123_7889ad74-aab3-4044-bcf4-13d6f9586a82_B"
     
     # Check devices list length
     devices = obs[0]["additional"]["devices"]


### PR DESCRIPTION
# Description

Add support for the new userId field. Now, different deployments with the same serialNumber will be handled as different deployments if they come from different accounts/users